### PR TITLE
Feat: Add multi-folder and source code indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,15 +197,21 @@ This is the most crucial step. You need to tell Cline how to start the `tool_syn
 
 After restarting VS Code, open the Cline chat. Type `@` and a list of available tools should appear. If you see **`@tool_sync_analyzer`** in the list, the connection was successful!
 
-#### Step 3: Index Your Work Items
+#### Step 3: Index Your Knowledge Base
 
-Before you can ask questions, the server needs to build its knowledge base from your local files.
+Before you can ask questions, the server needs to build its knowledge base. With the new version, you can index **multiple folders**, including your work items, source code, and automated tests.
 
-In the Cline chat, send the following command:
+In the Cline chat, send a command listing all the paths you want to index. **Paths can be absolute or relative.**
 
-> @tool_sync_analyzer index_documents work_items_path='work_items/'
+**Example for indexing work items and source code:**
+> @tool_sync_analyzer index_documents paths=['work_items/', 'src/', 'tests/']
 
-You should receive a success message like: `"Successfully indexed documents. The knowledge base is ready."`
+**Example using absolute paths (useful if running `tool_sync` from a different directory):**
+> @tool_sync_analyzer index_documents paths=['D:\\my_project\\work_items', 'D:\\my_project\\src']
+
+You should receive a success message like: `"Successfully indexed all provided paths. The knowledge base is ready."`
+
+This makes the analysis engine much more powerful, as it can now answer questions about your source code and tests in addition to your work items. It also allows the `tool_sync` server to be run from anywhere, as long as you provide absolute paths to the content you want to analyze.
 
 #### Step 4: Ask Questions!
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tool_sync',
-    version='0.5.0',
+    version='0.6.0',
     author='Fábio Ribeiro dos Santos Quispe',
     author_email='fabiorisantos1981@gmail.com',
     packages=find_packages(where="src"),

--- a/src/tool_sync/mcp_server.py
+++ b/src/tool_sync/mcp_server.py
@@ -1,7 +1,7 @@
 import logging
 import asyncio
 from mcp.server.fastmcp import FastMCP
-from typing import Optional
+from typing import Optional, List
 
 from .analysis.indexing import build_index
 from .analysis.query import query_index
@@ -16,23 +16,21 @@ mcp = FastMCP(
 )
 
 @mcp.tool()
-def index_documents(work_items_path: str) -> str:
+def index_documents(paths: List[str]) -> str:
     """
-    Builds or updates the knowledge base from local work item files.
+    Builds or updates the knowledge base from a list of local directories.
+    Can index work items, source code, and other text files.
 
-    :param work_items_path: The relative path to the directory containing the work item files (e.g., 'work_items/').
+    :param paths: A list of local directory or file paths to index. Paths can be absolute or relative.
     """
-    logger.info(f"Received request to index documents at path: {work_items_path}")
-    if not work_items_path:
-        raise ValueError("'work_items_path' is a required parameter.")
+    logger.info(f"Received request to index documents at paths: {paths}")
+    if not paths:
+        raise ValueError("'paths' is a required parameter and cannot be empty.")
 
-    # Running indexing in a separate thread to not block the server,
-    # but FastMCP handles async calls correctly.
-    # For simplicity, we'll run it directly. If it's too slow,
-    # we can use asyncio.to_thread in the future.
     try:
-        build_index(work_items_path)
-        return "Successfully indexed documents. The knowledge base is ready."
+        # The build_index function now accepts a list of paths
+        build_index(paths)
+        return "Successfully indexed all provided paths. The knowledge base is ready."
     except Exception as e:
         logger.error(f"Error during indexing: {e}", exc_info=True)
         raise ValueError(f"An error occurred during indexing: {e}")


### PR DESCRIPTION
This commit enhances the analysis engine to support indexing multiple, arbitrary local directories, including source code repositories.

Key changes:
- The `build_index` function in `indexing.py` now accepts a list of paths and can differentiate between structured work item files (.md) and plain text source code files (e.g., .py, .js).
- The `index_documents` tool in `mcp_server.py` is updated to accept a list of paths as an argument.
- The `README.md` is updated to document this new capability, explaining how to index work items and source code together.

This change makes the RAG pipeline much more powerful and also allows the analysis server to be run from any location, as long as absolute paths are provided to the tool. This completes the second and third major feature requests from the user. The project version is bumped to 0.6.0.