### PR TITLE
Fix UUID error during document indexing

### DIFF
--- a/src/tool_sync/analysis/indexing.py
+++ b/src/tool_sync/analysis/indexing.py
@@ -1,6 +1,7 @@
 import os
 import re
 import logging
+import uuid
 from typing import List, Dict, Any, Generator
 
 import yaml
@@ -72,7 +73,7 @@ def _parse_work_item_file(file_path: str) -> Dict[str, Any] | None:
             metadata[key] = str(value)
 
         return {
-            "id": str(metadata.get("id")),
+            "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, file_path)),
             "document": f"Title: {metadata.get('title', '')}\n\n{cleaned_body}",
             "metadata": { "file_type": "work_item", "file_path": file_path, **metadata }
         }
@@ -92,7 +93,7 @@ def _parse_plain_text_file(file_path: str) -> Dict[str, Any] | None:
             return None # Skip empty files
 
         return {
-            "id": file_path, # Use file path as the unique ID for code files
+            "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, file_path)),
             "document": content,
             "metadata": { "file_type": "source_code", "file_path": file_path }
         }


### PR DESCRIPTION
The `index_documents` tool was failing with the error `Point id ... is not a valid UUID`. This was because the document IDs being generated were either integer strings (from work item metadata) or file paths, neither of which are valid UUIDs as required by the Qdrant database.

This commit fixes the issue by generating a deterministic UUID for each document based on its file path using `uuid.uuid5`. This ensures that all documents have a valid and unique ID, resolving the indexing error.

Note: The existing test suite is failing due to issues unrelated to this change. The tests appear to be broken on the main branch after a recent refactoring of the configuration handling.